### PR TITLE
Auto-cancel of the winning leg in combined SL

### DIFF
--- a/lib/browserUtils.ts
+++ b/lib/browserUtils.ts
@@ -98,8 +98,7 @@ const getSchedulingApiProps = ({
   autoSquareOffProps: isAutoSquareOffEnabled
     ? {
         time: squareOffTime,
-        deletePendingOrders:
-          exitStrategy !== EXIT_STRATEGIES.MULTI_LEG_PREMIUM_THRESHOLD
+        deletePendingOrders:true
       }
     : undefined,
   expiresAt: expireIfUnsuccessfulInMins

--- a/lib/exit-strategies/autoSquareOff.ts
+++ b/lib/exit-strategies/autoSquareOff.ts
@@ -134,7 +134,7 @@ async function autoSquareOffStrat ({
   const completedOrders = rawKiteOrdersResponse
 
   if (deletePendingOrders) {
-    // console.log('deletePendingOrders init')
+     console.log('deletePendingOrders init')
     try {
       await doDeletePendingOrders(completedOrders, kite)
       // console.log('🟢 deletePendingOrders success', res)
@@ -143,6 +143,7 @@ async function autoSquareOffStrat ({
       console.error(e)
     }
   }
+  console.log('Calling SquareOff positions')
   return doSquareOffPositions(completedOrders, kite, initialJobData)
 }
 

--- a/lib/exit-strategies/multiLegPremiumThreshold.ts
+++ b/lib/exit-strategies/multiLegPremiumThreshold.ts
@@ -101,7 +101,7 @@ async function multiLegPremiumThreshold ({
 
     if (getTimeLeftInMarketClosingMs() < 0 ||
       (isAutoSquareOffEnabled &&
-        isTimeAfterAutoSquareOff(time))) {
+        isTimeAfterAutoSquareOff(time!))) {
       return Promise.resolve(
         '🟢 [multiLegPremiumThreshold] Terminating Combined Premium checker as market closing or after square off time..'
       )

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -245,6 +245,20 @@ export const getTimeLeftInMarketClosingMs = () =>
     ? ms(1 * 60 * 60) // if developing, hardcode one hour to market closing
     : dayjs(getMisOrderLastSquareOffTime()).diff(dayjs())
 
+//Returns a boolean to check if current time is after square off time
+export const isTimeAfterAutoSquareOff=(squareOffTime?: string)=>
+{
+const finalOrderTime = getMisOrderLastSquareOffTime()
+const runAtTime = isMockOrder()
+  ? squareOffTime
+  : dayjs(squareOffTime).isAfter(dayjs(finalOrderTime))
+  ? finalOrderTime
+  : squareOffTime
+
+ return dayjs().isAfter(runAtTime);
+
+}
+
 export const getEntryAttemptsCount = ({ strategy }) => {
   switch (strategy) {
     case STRATEGIES.DIRECTIONAL_OPTION_SELLING:

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -246,7 +246,7 @@ export const getTimeLeftInMarketClosingMs = () =>
     : dayjs(getMisOrderLastSquareOffTime()).diff(dayjs())
 
 //Returns a boolean to check if current time is after square off time
-export const isTimeAfterAutoSquareOff=(squareOffTime?: string)=>
+export const isTimeAfterAutoSquareOff=(squareOffTime: string)=>
 {
 const finalOrderTime = getMisOrderLastSquareOffTime()
 const runAtTime = isMockOrder()


### PR DESCRIPTION
Have made two changes:

- SLM buy of winning leg should be auto-cancelled
- After auto-square off time, the queue should not run. 